### PR TITLE
Adjust Tidal platform regex to allow for album links

### DIFF
--- a/tg_odesli_bot/platforms.py
+++ b/tg_odesli_bot/platforms.py
@@ -102,6 +102,8 @@ class TidalPlatform(PlatformABC):
     """Tidal platform."""
 
     key = 'tidal'
-    url_re = r'https?://(www\.|listen\.)?tidal\.com(/browse)?/track/\d+'
+    url_re = (
+        r'https?://(www\.|listen\.)?tidal\.com(/browse)?/(track|album)/\d+'
+    )
     name = 'Tidal'
     order = 8


### PR DESCRIPTION
Hey! Following up on my recent PR a friend told me Tidal's Album links are also supported by Odesli. I adjusted the regex to detect them.
