### PR TITLE
Add note about YouTube links not handled in group chats to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Currently the following services are supported:
   - Apple Music
   - Tidal
 
+Note that bot doesn't react to YouTube links in group chats. Reasons are [here](https://github.com/9dogs/tg-odesli-bot/issues/12).
+
 ## Privacy considerations
 
 The bot have to have access to messages in group chats to operate (that


### PR DESCRIPTION
I spent 10 minutes wondering why YouTube doesn't have any effect 😃. I think it's worth mentioning in the docs. 

Submitted with [Web Publisher](https://developer.stackblitz.com/codeflow/integrating-web-publisher)