### PR TITLE
Identify Spotify international URLs

### DIFF
--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -34,7 +34,8 @@ class TestOdesliBot:
             '17 https://carbonbasedlifeforms.bandcamp.com/track/6equj5\n'
             '18 https://youtu.be/ugYB3VxpivU\n'
             '19 https://spotify.link/a9uvoB7YQyb\n'
-            '20 https://open.spotify.com/intl-pt/track/1g6F8wj3IME7EiJ0L0tmzy?si=e3295c2850eb4a4f'
+            '20 https://open.spotify.com/intl-pt/track/1g6F8wj3IME7EiJ0L0tmzy'
+            '?si=e3295c2850eb4a4f'
         )
         urls = bot.extract_song_urls(text)
         assert len(urls) == 20

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -33,10 +33,11 @@ class TestOdesliBot:
             'complex-world\n'
             '17 https://carbonbasedlifeforms.bandcamp.com/track/6equj5\n'
             '18 https://youtu.be/ugYB3VxpivU\n'
-            '19 https://spotify.link/a9uvoB7YQyb'
+            '19 https://spotify.link/a9uvoB7YQyb\n'
+            '20 https://open.spotify.com/intl-pt/track/1g6F8wj3IME7EiJ0L0tmzy?si=e3295c2850eb4a4f'
         )
         urls = bot.extract_song_urls(text)
-        assert len(urls) == 19
+        assert len(urls) == 20
         deezer_url = urls[0]
         assert deezer_url.platform_key == 'deezer'
         assert deezer_url.url == 'https://www.deezer.com/track/568497412'
@@ -118,6 +119,11 @@ class TestOdesliBot:
         assert bandcamp_track.platform_key == 'bandcamp'
         assert bandcamp_track.url == (
             'https://carbonbasedlifeforms.bandcamp.com/track/6equj5'
+        )
+        spotify_intl_track = urls[19]
+        assert spotify_intl_track.platform_key == 'spotify'
+        assert spotify_intl_track.url == (
+            'https://open.spotify.com/intl-pt/track/1g6F8wj3IME7EiJ0L0tmzy'
         )
 
     @mark.parametrize(

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -79,52 +79,53 @@ class TestOdesliBot:
         spotify = urls[9]
         assert spotify.platform_key == 'spotify'
         assert spotify.url == 'https://spotify.link/a9uvoB7YQyb'
-        youtube_music = urls[10]
+        spotify = urls[10]
+        assert spotify.platform_key == 'spotify'
+        assert spotify.url == (
+            'https://open.spotify.com/intl-pt/track/1g6F8wj3IME7EiJ0L0tmzy'
+            '?si=e3295c2850eb4a4f'
+        )
+        youtube_music = urls[11]
         assert youtube_music.platform_key == 'youtubeMusic'
         assert youtube_music.url == (
             'https://music.youtube.com/watch?v=eVTXPUF4Oz4'
         )
-        youtube_music_album = urls[11]
+        youtube_music_album = urls[12]
         assert youtube_music_album.platform_key == 'youtubeMusic'
         assert youtube_music_album.url == (
             'https://music.youtube.com/playlist?list='
             'OLAK5uy_l2F5ezYgFM0mQ3tg2-vK900BTgr8zXMW0'
         )
-        youtube = urls[12]
+        youtube = urls[13]
         assert youtube.platform_key == 'youtube'
         assert youtube.url == 'https://www.youtube.com/watch?v=eVTXPUF4Oz4'
-        youtube_album = urls[13]
+        youtube_album = urls[14]
         assert youtube_album.platform_key == 'youtube'
         assert youtube_album.url == (
             'https://www.youtube.com/playlist?list='
             'OLAK5uy_n64ojqXEYWqrvO5GAWU1Ik040wTIzBdbQ'
         )
-        youtube_short = urls[14]
+        youtube_short = urls[15]
         assert youtube_short.platform_key == 'youtube'
         assert youtube_short.url == 'https://youtu.be/ugYB3VxpivU'
-        apple_music = urls[15]
+        apple_music = urls[16]
         assert apple_music.platform_key == 'appleMusic'
         assert apple_music.url == (
             'https://music.apple.com/se/album/raindrops-feat-j3po/1450701158'
         )
-        tidal = urls[16]
+        tidal = urls[17]
         assert tidal.platform_key == 'tidal'
         assert tidal.url == 'https://tidal.com/track/139494756'
-        bandcamp_album = urls[17]
+        bandcamp_album = urls[18]
         assert bandcamp_album.platform_key == 'bandcamp'
         assert bandcamp_album.url == (
             'https://gunnarspardel.bandcamp.com/album/simplicity-in-a-'
             'complex-world'
         )
-        bandcamp_track = urls[18]
+        bandcamp_track = urls[19]
         assert bandcamp_track.platform_key == 'bandcamp'
         assert bandcamp_track.url == (
             'https://carbonbasedlifeforms.bandcamp.com/track/6equj5'
-        )
-        spotify_intl_track = urls[19]
-        assert spotify_intl_track.platform_key == 'spotify'
-        assert spotify_intl_track.url == (
-            'https://open.spotify.com/intl-pt/track/1g6F8wj3IME7EiJ0L0tmzy'
         )
 
     @mark.parametrize(

--- a/tg_odesli_bot/platforms.py
+++ b/tg_odesli_bot/platforms.py
@@ -71,7 +71,7 @@ class SpotifyPlatform(PlatformABC):
 
     key = 'spotify'
     url_re = (
-        r'https?://([a-zA-Z\d-]+\.)*((spotify\.com/(album|track)/[^\s.,]*)'
+        r'https?://([a-zA-Z\d-]+\.)*((spotify\.com/(?:intl-\w+/)?(album|track)/[^\s.,]*)'
         r'|(tospotify\.com/[^\s.,]*)'
         r'|(spotify\.link/[^\s]*))'
     )

--- a/tg_odesli_bot/platforms.py
+++ b/tg_odesli_bot/platforms.py
@@ -71,7 +71,8 @@ class SpotifyPlatform(PlatformABC):
 
     key = 'spotify'
     url_re = (
-        r'https?://([a-zA-Z\d-]+\.)*((spotify\.com/(?:intl-\w+/)?(album|track)/[^\s.,]*)'
+        r'https?://([a-zA-Z\d-]+\.)*'
+        r'((spotify\.com/(?:intl-\w+/)?(album|track)/[^\s.,]*)'
         r'|(tospotify\.com/[^\s.,]*)'
         r'|(spotify\.link/[^\s]*))'
     )


### PR DESCRIPTION
Add support for Spotify international URLs.

Regexp was tested using https://pythex.org/

Don't know the format of other country codes but I expect `\w+` to be sufficient.

Used `?:` to avoid creating a new matching group and breaking anything elsewhere but if that's not the case these could be removed to simplify the regexp.